### PR TITLE
fix: removed unused import in App.jsx

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,6 @@ import AddTask from './components/AddTask.jsx'
 import TaskList from './components/TaskList.jsx'
 import Counter from './components/Counter.jsx'
 import Footer from './components/Footer.jsx'
-// BUG (issue #11): unused import left in the file
-import { useCallback } from 'react'
 
 let nextId = 3
 


### PR DESCRIPTION
## What & Why
Fixes #23 

## Changes
- removed unused import of useCallback in App.jsx

## Testing
- [x] I ran the app locally OR verified the change by reading the code.

## Checklist
- [x] Branch named like `fix/<issue>-desc`
- [x] Only one issue addressed
- [x] Linked the issue with `Fixes #`
